### PR TITLE
Add SuperGrok Mac (native macOS app for the Grok coding agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Libraries and integrations to build with Grok.
 | xai_grok_sdk | Lightweight third-party Python library for Grok API with minimal dependencies and function calling support. | [GitHub](https://github.com/moesmufti/xai_grok_sdk) |
 | LangChain xAI Integration | LangChain support for xAI models, enabling easy integration with Grok for chat and streaming tasks. | [Documentation](https://python.langchain.com/docs/integrations/providers/xai/) |
 | Hugging Face Integration | Use Grok models with Hugging Face’s Transformers library. | [Hugging Face Hub](https://huggingface.co/xai) |
+| SuperGrok Mac | Free, Apple-notarized native macOS app (Apple Silicon, macOS 14+) for working with Grok's coding agent — real project folders, a real shell with approval gates on every command, and restorable sessions. Fan-built, not affiliated with xAI; requires your own SuperGrok subscription or xAI API key. | [Website](https://supergrokmac.com) |
 
 ## CLI Tools
 Command-line tools for interacting with Grok.


### PR DESCRIPTION
## Add SuperGrok Mac

**[SuperGrok Mac](https://supergrokmac.com)** is a free, Apple-notarized (Developer ID, ticket stapled) native macOS app for working with xAI's Grok 4.5 coding agent. It gives the agent a proper working environment: real project folders, a real shell with approval gates on every command, restorable sessions, and a ⌘K command palette. Requires macOS 14+ on Apple Silicon and the user's own SuperGrok subscription or xAI API key. It is independent and fan-built — not affiliated with xAI.

Added as a row in the Tools and Libraries table. Link is valid (checked today).

**Disclosure:** we maintain the app's website (supergrokmac.com), and this PR was prepared with AI assistance.
