### PR TITLE
Add Agent Teams AI to Tools and Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Libraries and integrations to build with Grok.
 | LangChain xAI Integration | LangChain support for xAI models, enabling easy integration with Grok for chat and streaming tasks. | [Documentation](https://python.langchain.com/docs/integrations/providers/xai/) |
 | Hugging Face Integration | Use Grok models with Hugging Face’s Transformers library. | [Hugging Face Hub](https://huggingface.co/xai) |
 | SuperGrok Mac | Free, Apple-notarized native macOS app (Apple Silicon, macOS 14+) for working with Grok's coding agent — real project folders, a real shell with approval gates on every command, and restorable sessions. Fan-built, not affiliated with xAI; requires your own SuperGrok subscription or xAI API key. | [Website](https://supergrokmac.com) |
+| Agent Teams AI | Free, open-source desktop app for autonomous coding-agent teams, with SuperGrok support, task delegation, inter-agent messaging, a live Kanban board, and code review. | [GitHub](https://github.com/777genius/agent-teams-ai) |
 
 ## CLI Tools
 Command-line tools for interacting with Grok.


### PR DESCRIPTION
Adds Agent Teams AI to the Tools and Libraries section.

The app lets users run SuperGrok as part of autonomous coding-agent teams with task delegation, inter-agent messaging, a live Kanban board, and code review.

Validation:

- Confirmed the project link and current SuperGrok support
- Checked for existing entries, issues, and pull requests
- Ran `git diff --check`

Disclosure: I maintain Agent Teams AI.
