### PR TITLE
Add HyperGrok Trading Desk to Tools and Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Libraries and integrations to build with Grok.
 | Aeon | Autonomous agent framework that runs unattended on GitHub Actions and drives Grok (via its harness adapter) as one of six coding-agent harnesses behind a single contract, with quality scoring, persistent memory, and a self-healing loop. | [GitHub](https://github.com/aeonfun/aeon) |
 | Agent Island | Free, MIT-licensed native status companion that shows local working, stalled and your-turn state for Grok, Claude Code, Codex, Antigravity and Cursor sessions, with provider usage and on-device cost estimates. macOS and Windows, no account, no product telemetry. | [GitHub](https://github.com/tristan666666/agent-island) |
 | Forge Design | Chrome extension + local bridge: pick or place a component on the live page, then local Grok edits the UI. Page data stays on-device. MIT. | [GitHub](https://github.com/forge-ui/forge-design-extension) |
+| HyperGrok Trading Desk | Grok-first Hyperliquid desk: seven agent skills for setup, orders, positions, market data, and a strategy lab. `npx skills add galleonlabs/hypergrok-trading-desk` | [GitHub](https://github.com/galleonlabs/hypergrok-trading-desk) |
 
 ## CLI Tools
 Command-line tools for interacting with Grok.
@@ -130,6 +131,7 @@ To add resources, submit a pull request to [Awesome Grok Repository](https://git
 ## Changelog
 Track updates to this list.
 
+- **August 2026**: Added HyperGrok Trading Desk, a Grok-first Hyperliquid desk of installable agent skills.
 - **August 2026**: Added Forge Design, a local-first Chrome extension for picking live page components and editing them with Grok.
 - **July 2025**: Added Grok 4 announcement, advanced tutorials, and community projects.
 - **March 2025**: Included Grok 3 Beta news and troubleshooting section.


### PR DESCRIPTION
HyperGrok Trading Desk under Tools and Libraries.

https://github.com/galleonlabs/hypergrok-trading-desk

Grok-first Hyperliquid desk. Install: `npx skills add galleonlabs/hypergrok-trading-desk`
