### PR TITLE
Add Porte remote control for Grok Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Curated resources for [Grok](https://x.ai/grok), [Grok Bot](https://x.ai/news/gr
 
 - [Cursor](https://www.cursor.com/) — AI-first code editor featuring native Grok 4.6 integration and SpaceX Colossus GPU compute backends.
 - [Grok Bot](https://x.ai/news/grok-bot-more-plans) — Official SpaceXAI autonomous agent teammate for work automation and X API actions.
+- [Porte](https://github.com/alexander-zuev/porte) — Open-source phone remote control for Grok Build sessions with live transcripts, prompts, commands, and permission approvals.
 - [SuperGrok Mac](https://supergrokmac.com) — Native macOS desktop client for Grok coding agents with local folder access, approval gates, and session management.
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai) — Open-source desktop app for orchestrating autonomous coding-agent teams using Grok.
 - [Aeon](https://github.com/aeonfun/aeon) — Unattended GitHub Actions agent loop utilizing Grok as an execution harness.


### PR DESCRIPTION
Adds Porte, an open-source phone remote control for Grok Build sessions.

I placed it under **Apps and Agents** because it provides a phone interface through a Grok plugin. Would you prefer **CLI** or another section?